### PR TITLE
feat: implement custom log fmter to strip APIKey

### DIFF
--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -145,7 +147,7 @@ var (
 
 	// System
 	versionInfo = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "version_info"), "Nagios version information", []string{"version"}, nil)
-	buildInfo = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "build_info"), "Nagios exporter build information", []string{"version", "build_date", "commit"}, nil)
+	buildInfo   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "build_info"), "Nagios exporter build information", []string{"version", "build_date", "commit"}, nil)
 
 	// System Detail
 	hostchecks    = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "host_checks_minutes"), "Host checks over time", []string{"check_type"}, nil)
@@ -592,6 +594,27 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	log.Info("Endpoint scraped and metrics updated")
 }
 
+// custom formatter modified from https://github.com/sirupsen/logrus/issues/719#issuecomment-536459432
+// https://stackoverflow.com/questions/48971780/how-to-change-the-format-of-log-output-in-logrus/48972299#48972299
+// required as Nagios XI API only supports giving the API token as a URL parameter, and thus can be leaked in the logs
+type nagiosFormatter struct {
+	log.TextFormatter
+	APIKey string
+}
+
+func (f *nagiosFormatter) Format(entry *log.Entry) ([]byte, error) {
+	log, newEntry := f.TextFormatter.Format(entry)
+
+	// there might be a better way to do this but, convert our log byte array to a string
+	logString := string(log[:])
+	// replace the secret APIKey with junk
+	cleanString := strings.ReplaceAll(logString, f.APIKey, "<redactedAPIKey>")
+	// return it to a byte and pass it on
+	cleanLog := []byte(cleanString)
+
+	return bytes.Trim(cleanLog, f.APIKey), newEntry
+}
+
 func main() {
 
 	var (
@@ -622,6 +645,10 @@ func main() {
 	}
 
 	var conf Config = ReadConfig(*configPath)
+
+	formatter := nagiosFormatter{}
+	formatter.APIKey = conf.APIKey
+	log.SetFormatter(&formatter)
 
 	nagiosURL := *remoteAddress + nagiosAPIVersion + apiSlug
 


### PR DESCRIPTION
NagiosXI seems to only support using an API key as a URL parameter, which leads to leakage on errors stemming from HTTP requests, such as the scrape.uri not being a Nagios endpoint.

This implements a custom logrus log formatter to strips the API key and replaces it with junk indicating the API key has been redacted - and therefore, keeping this keys out of logs.

Output:
```
/usr/local/bin/prometheus-nagios-exporter --nagios.scrape-uri google.com
INFO[0000] Using connection endpoint: google.com
FATA[0003] Get
"google.com/nagiosxi/api/v1/system/status?apikey=<redactedAPIKey>":
unsupported protocol scheme ""
```

Resolves #12 