### PR TITLE
feat: Nagios Core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ It is also recommended to pass the path of the Nagios configuration
 
 Typical location and usage of the binary:
 
-* Nagios Core 3/4: `/usr/local/nagios/bin/nagiostats -c /usr/local/nagios/etc/nagios.cfg`
-* CheckMK: `/omd/sites/<your-site>/bin/nagiostats -c /omd/sites/<your-site>/tmp/nagios/nagios.cfg`
+* Nagios Core 3/4:
+  * `--nagios.stats_binary`: `/usr/local/nagios/bin/nagiostats`
+  * `--nagios.config_path`: `/usr/local/nagios/etc/nagios.cfg`
+* CheckMK:
+  * `--nagios.stats_binary`: `/omd/sites/<your-site>/bin/nagiostats`
+  * `--nagios.config_path`: `/omd/sites/<your-site>/tmp/nagios/nagios.cfg`
 
 Example usage:
 
 ```bash
-./nagios_exporter --nagios.stats_binary "/usr/local/nagios/bin/nagiostats -c /usr/local/nagios/etc/nagios.cfg"
+./nagios_exporter --nagios.stats_binary "/usr/local/nagios/bin/nagiostats" --nagios.config_path "/usr/local/nagios/etc/nagios.cfg"
 ```
 
 Note that this flag nullifies all others. It cannot be used in conjunction with the Nagios XI API.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 ![Go Report Card](https://goreportcard.com/badge/github.com/wbollock/nagios_exporter)
 [![contributions](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat")](https://github.com/wbollock/nagios_exporter/issues)
 
-
 A Prometheus exporter currently supporting:
 
 * Nagios XI
+* Nagios Core 4
+* Nagios Core 3
+* CheckMK
 
 It includes metrics on the current state and configuration of Nagios. This includes the number of hosts, services, and information about their monitoring setup. For example, this exporter will output the number of flapping hosts, passive checks, or hosts in downtime.
 
@@ -21,6 +23,7 @@ Practical use cases for this exporter may include:
 This exporter does not output Nagios check results as Prometheus metrics; it is designed to export metrics of the Nagios monitoring server itself for meta-monitoring.
 
 ## Table of Contents
+
 - [nagios_exporter](#nagios_exporter)
   - [Table of Contents](#table-of-contents)
   - [Configuration](#configuration)
@@ -55,6 +58,25 @@ To see all available configuration flags:
 ```bash
 ./prometheus-nagios-exporter -h
 ```
+
+### Nagios Core 3/4 support
+
+This exporter also supports Nagios Core 3/4 and CheckMK, albeit with a subset of metrics and reliance on the `nagiosstats` binary. There is no RESTful API for either monitoring platform, so the exporter must be run directly on the Nagios host and have access to execute `nagiostats`.
+
+It is also recommended to pass the path of the Nagios configuration
+
+Typical location and usage of the binary:
+
+* Nagios Core 3/4: `/usr/local/nagios/bin/nagiostats -c /usr/local/nagios/etc/nagios.cfg`
+* CheckMK: `/omd/sites/<your-site>/bin/nagiostats -c /omd/sites/<your-site>/tmp/nagios/nagios.cfg`
+
+Example usage:
+
+```bash
+./nagios_exporter --nagios.stats_binary "/usr/local/nagios/bin/nagiostats -c /usr/local/nagios/etc/nagios.cfg"
+```
+
+Note that this flag nullifies all others. It cannot be used in conjunction with the Nagios XI API.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,22 @@ Import the [dashboard](grafana/dashboard.json) template ([instructions](https://
 
 ## Troubleshooting
 
-Ensure `nagios_up` returns `1`, otherwise please check your API key and Nagios reachability, such as:
+Ensure `nagios_up` returns `1`.
+
+### NagiosXI
+
+Please check your API key and Nagios reachability:
 
 ```bash
 curl -GET "http://<nagios_url>/nagiosxi/api/v1/objects/host?apikey=<apikey>&pretty=1"
+```
+
+### Nagios Core 3/4, CheckMK
+
+Ensure the user running the Nagios Exporter can execute `nagiostats` fully:
+
+```bash
+sudo su <prometheus-user> -s /bin/bash -c "/usr/local/nagios/bin/nagiostats -c /usr/local/nagios/etc/nagios.cfg"
 ```
 
 ## Resources Used

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -49,36 +49,36 @@ type systemStatusDetail struct {
 			AvgLatency       float64 `json:"avg_latency,string"`
 			MaxExecutionTime float64 `json:"max_execution_time,string"`
 			MaxLatency       float64 `json:"max_latency,string"`
-			MinExecutionTime int64   `json:"min_execution_time,string"`
-			MinLatency       int64   `json:"min_latency,string"`
+			MinExecutionTime float64 `json:"min_execution_time,string"`
+			MinLatency       float64 `json:"min_latency,string"`
 		} `json:"activehostcheckperf"`
 		Activehostchecks struct {
-			Val1  int64 `json:"val1,string"`
-			Val15 int64 `json:"val15,string"`
-			Val5  int64 `json:"val5,string"`
+			Val1  float64 `json:"val1,string"`
+			Val15 float64 `json:"val15,string"`
+			Val5  float64 `json:"val5,string"`
 		} `json:"activehostchecks"`
 		Activeservicecheckperf struct {
 			AvgExecutionTime float64 `json:"avg_execution_time,string"`
 			AvgLatency       float64 `json:"avg_latency,string"`
 			MaxExecutionTime float64 `json:"max_execution_time,string"`
 			MaxLatency       float64 `json:"max_latency,string"`
-			MinExecutionTime int64   `json:"min_execution_time,string"`
-			MinLatency       int64   `json:"min_latency,string"`
+			MinExecutionTime float64 `json:"min_execution_time,string"`
+			MinLatency       float64 `json:"min_latency,string"`
 		} `json:"activeservicecheckperf"`
 		Activeservicechecks struct {
-			Val1  int64 `json:"val1,string"`
-			Val15 int64 `json:"val15,string"`
-			Val5  int64 `json:"val5,string"`
+			Val1  float64 `json:"val1,string"`
+			Val15 float64 `json:"val15,string"`
+			Val5  float64 `json:"val5,string"`
 		} `json:"activeservicechecks"`
 		Passivehostchecks struct {
-			Val1  int64 `json:"val1,string"`
-			Val15 int64 `json:"val15,string"`
-			Val5  int64 `json:"val5,string"`
+			Val1  float64 `json:"val1,string"`
+			Val15 float64 `json:"val15,string"`
+			Val5  float64 `json:"val5,string"`
 		} `json:"passivehostchecks"`
 		Passiveservicechecks struct {
-			Val1  int64 `json:"val1,string"`
-			Val15 int64 `json:"val15,string"`
-			Val5  int64 `json:"val5,string"`
+			Val1  float64 `json:"val1,string"`
+			Val15 float64 `json:"val15,string"`
+			Val5  float64 `json:"val5,string"`
 		} `json:"passiveservicechecks"`
 		Updated string `json:"updated"`
 	} `json:"nagioscore"`
@@ -90,19 +90,19 @@ type systemInfo struct {
 
 // generated with https://github.com/bashtian/jsonutils
 type hostStatus struct {
-	Recordcount int64 `json:"recordcount"`
+	Recordcount float64 `json:"recordcount"`
 	Hoststatus  []struct {
 		HostObjectID               float64 `json:"host_object_id,string"`
 		CheckType                  float64 `json:"check_type,string"`
 		CurrentState               float64 `json:"current_state,string"`
 		IsFlapping                 float64 `json:"is_flapping,string"`
 		ScheduledDowntimeDepth     float64 `json:"scheduled_downtime_depth,string"`
-		ProblemHasBeenAcknowledged int64   `json:"problem_has_been_acknowledged,string"`
+		ProblemHasBeenAcknowledged float64 `json:"problem_has_been_acknowledged,string"`
 	} `json:"hoststatus"`
 }
 
 type serviceStatus struct {
-	Recordcount   int64 `json:"recordcount"`
+	Recordcount   float64 `json:"recordcount"`
 	Servicestatus []struct {
 		HasBeenChecked             float64 `json:"has_been_checked,string"`
 		ShouldBeScheduled          float64 `json:"should_be_scheduled,string"`
@@ -110,16 +110,16 @@ type serviceStatus struct {
 		CurrentState               float64 `json:"current_state,string"`
 		IsFlapping                 float64 `json:"is_flapping,string"`
 		ScheduledDowntimeDepth     float64 `json:"scheduled_downtime_depth,string"`
-		ProblemHasBeenAcknowledged int64   `json:"problem_has_been_acknowledged,string"`
+		ProblemHasBeenAcknowledged float64 `json:"problem_has_been_acknowledged,string"`
 	} `json:"servicestatus"`
 }
 
 type userStatus struct {
 	// yes, this field is named records even though every other endpoint is `recordcount`...
-	Recordcount int64 `json:"records"`
+	Recordcount float64 `json:"records"`
 	Userstatus  []struct {
-		Admin   int64 `json:"admin,string"`
-		Enabled int64 `json:"enabled,string"`
+		Admin   float64 `json:"admin,string"`
+		Enabled float64 `json:"enabled,string"`
 	} `json:"users"`
 }
 
@@ -373,11 +373,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		log.Fatal(jsonErr)
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		hostsTotal, prometheus.GaugeValue, float64(hostStatusObject.Recordcount),
-	)
-
-	var hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount, hostsFlapCount, hostsDowntimeCount, hostsProblemsAcknowledgedCount int
+	var hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount, hostsFlapCount, hostsDowntimeCount, hostsProblemsAcknowledgedCount float64
 
 	// iterate through nested json
 	for _, v := range hostStatusObject.Hoststatus {
@@ -458,13 +454,9 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		log.Fatal(jsonErr)
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		servicesTotal, prometheus.GaugeValue, float64(serviceStatusObject.Recordcount),
-	)
-
 	var servicesCount, servicesScheduledCount, servicesActiveCheckCount,
 		servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesCriticalCount,
-		servicesUnknownCount, servicesFlapCount, servicesDowntimeCount, servicesProblemsAcknowledgedCount int
+		servicesUnknownCount, servicesFlapCount, servicesDowntimeCount, servicesProblemsAcknowledgedCount float64
 
 	for _, v := range serviceStatusObject.Servicestatus {
 
@@ -661,10 +653,10 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		log.Fatal(jsonErr)
 	}
 
-	var usersAdminCount, usersRegularCount, usersEnabledCount, usersDisabledCount int
+	var usersAdminCount, usersRegularCount, usersEnabledCount, usersDisabledCount float64
 
 	ch <- prometheus.MustNewConstMetric(
-		usersTotal, prometheus.GaugeValue, float64(userStatusObject.Recordcount),
+		usersTotal, prometheus.GaugeValue, userStatusObject.Recordcount,
 	)
 
 	for _, v := range userStatusObject.Userstatus {
@@ -836,30 +828,10 @@ func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, 
 		servicesDowntime, prometheus.GaugeValue, servicesDowntimeCount,
 	)
 
-	// check performance
-	var activehostchecks1m, activehostchecks5m, activehostchecks15m,
-		passivehostchecks1m, passivehostchecks5m, passivehostchecks15m,
-		activeservicechecks1m, activeservicechecks5m, activeservicechecks15m,
-		passiveservicechecks1m, passiveservicechecks5m, passiveservicechecks15m float64
-
-	activehostchecks1m = metricSlice[18]   // NUMHSTACTCHK1M
-	activehostchecks5m = metricSlice[19]   // NUMHSTACTCHK5M
-	activehostchecks15m = metricSlice[20]  // NUMHSTACTCHK15M
-	passivehostchecks1m = metricSlice[21]  // NUMHSTPSVCHK1M
-	passivehostchecks5m = metricSlice[22]  // NUMHSTPSVCHK5M
-	passivehostchecks15m = metricSlice[23] // NUMHSTPSVCHK15M
-
-	activeservicechecks1m = metricSlice[24]   // NUMSVCACTCHK1M
-	activeservicechecks5m = metricSlice[25]   // NUMSVCACTCHK5M
-	activeservicechecks15m = metricSlice[26]  // NUMSVCACTCHK15M
-	passiveservicechecks1m = metricSlice[27]  // NUMSVCPSVCHK1M
-	passiveservicechecks5m = metricSlice[28]  // NUMSVCPSVCHK5M
-	passiveservicechecks15m = metricSlice[29] // NUMSVCPSVCHK15M
-
 	activeHostCheckSum := activehostchecks1m + activehostchecks5m + activehostchecks15m
 
 	ch <- prometheus.MustNewConstHistogram(
-		hostchecks, uint64(activeHostCheckSum), float64(activeHostCheckSum), map[float64]uint64{
+		hostchecks, uint64(activeHostCheckSum), activeHostCheckSum, map[float64]uint64{
 			1:  uint64(activehostchecks1m),
 			5:  uint64(activehostchecks5m),
 			15: uint64(activehostchecks15m)}, "active",
@@ -877,7 +849,7 @@ func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, 
 	activeserviceCheckSum := activeservicechecks1m + activeservicechecks5m + activeservicechecks15m
 
 	ch <- prometheus.MustNewConstHistogram(
-		servicechecks, uint64(activeserviceCheckSum), float64(activeserviceCheckSum), map[float64]uint64{
+		servicechecks, uint64(activeserviceCheckSum), activeserviceCheckSum, map[float64]uint64{
 			1:  uint64(activeservicechecks1m),
 			5:  uint64(activeservicechecks5m),
 			15: uint64(activeservicechecks15m)}, "active",

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -540,7 +540,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		servicesProblemsAcknowledged, prometheus.GaugeValue, float64(servicesProblemsAcknowledgedCount),
 	)
 
-	// service status
+	// system status
 	systemStatusDetailURL := e.nagiosEndpoint + systemstatusDetailAPI + "?apikey=" + e.nagiosAPIKey
 
 	body = QueryAPIs(systemStatusDetailURL, sslVerify, nagiosAPITimeout)

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -462,17 +462,13 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		servicesTotal, prometheus.GaugeValue, float64(serviceStatusObject.Recordcount),
 	)
 
-	var servicesCount, servicesCheckedCount, servicesScheduledCount, servicesActiveCheckCount,
+	var servicesCount, servicesScheduledCount, servicesActiveCheckCount,
 		servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesCriticalCount,
 		servicesUnknownCount, servicesFlapCount, servicesDowntimeCount, servicesProblemsAcknowledgedCount int
 
 	for _, v := range serviceStatusObject.Servicestatus {
 
 		servicesCount++
-
-		if v.HasBeenChecked == 0 {
-			servicesCheckedCount++
-		}
 
 		if v.ShouldBeScheduled == 0 {
 			servicesScheduledCount++
@@ -513,7 +509,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		servicesCheckedTotal, prometheus.GaugeValue, float64(hostsPassiveCheckCount), "passive",
+		servicesCheckedTotal, prometheus.GaugeValue, float64(servicesPassiveCheckCount), "passive",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
@@ -525,7 +521,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesWarnCount), "critical",
+		servicesStatus, prometheus.GaugeValue, float64(servicesCriticalCount), "critical",
 	)
 
 	ch <- prometheus.MustNewConstMetric(

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -356,10 +356,6 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 		versionInfo, prometheus.GaugeValue, 1, systemInfoObject.Version,
 	)
 
-	ch <- prometheus.MustNewConstMetric(
-		buildInfo, prometheus.GaugeValue, 1, Version, BuildDate, Commit,
-	)
-
 	// host status
 	hoststatusURL := e.nagiosEndpoint + hoststatusAPI + "?apikey=" + e.nagiosAPIKey
 
@@ -410,35 +406,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		hostsCheckedTotal, prometheus.GaugeValue, float64(hostsActiveCheckCount), "active",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsCheckedTotal, prometheus.GaugeValue, float64(hostsPassiveCheckCount), "passive",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsStatus, prometheus.GaugeValue, float64(hostsUpCount), "up",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsStatus, prometheus.GaugeValue, float64(hostsDownCount), "down",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsStatus, prometheus.GaugeValue, float64(hostsUnreachableCount), "unreachable",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsStatus, prometheus.GaugeValue, float64(hostsFlapCount), "flapping",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsDowntime, prometheus.GaugeValue, float64(hostsDowntimeCount),
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostsProblemsAcknowledged, prometheus.GaugeValue, float64(hostsProblemsAcknowledgedCount),
+		hostsProblemsAcknowledged, prometheus.GaugeValue, hostsProblemsAcknowledgedCount,
 	)
 
 	// service status
@@ -497,39 +465,7 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		servicesCheckedTotal, prometheus.GaugeValue, float64(servicesActiveCheckCount), "active",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesCheckedTotal, prometheus.GaugeValue, float64(servicesPassiveCheckCount), "passive",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesOkCount), "ok",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesWarnCount), "warn",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesCriticalCount), "critical",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesUnknownCount), "unknown",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesStatus, prometheus.GaugeValue, float64(servicesFlapCount), "flapping",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesDowntime, prometheus.GaugeValue, float64(servicesDowntimeCount),
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicesProblemsAcknowledged, prometheus.GaugeValue, float64(servicesProblemsAcknowledgedCount),
+		servicesProblemsAcknowledged, prometheus.GaugeValue, servicesProblemsAcknowledgedCount,
 	)
 
 	// system status
@@ -544,100 +480,6 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	if jsonErr != nil {
 		log.Fatal(jsonErr)
 	}
-
-	activeHostCheckSum := systemStatusDetailObject.Nagioscore.Activehostchecks.Val1 +
-		systemStatusDetailObject.Nagioscore.Activehostchecks.Val5 +
-		systemStatusDetailObject.Nagioscore.Activehostchecks.Val15
-
-	ch <- prometheus.MustNewConstHistogram(
-		hostchecks, uint64(activeHostCheckSum), float64(activeHostCheckSum), map[float64]uint64{
-			1:  uint64(systemStatusDetailObject.Nagioscore.Activehostchecks.Val1),
-			5:  uint64(systemStatusDetailObject.Nagioscore.Activehostchecks.Val5),
-			15: uint64(systemStatusDetailObject.Nagioscore.Activehostchecks.Val15)}, "active",
-	)
-
-	passiveHostCheckSum := systemStatusDetailObject.Nagioscore.Passivehostchecks.Val1 +
-		systemStatusDetailObject.Nagioscore.Passivehostchecks.Val5 +
-		systemStatusDetailObject.Nagioscore.Passivehostchecks.Val15
-
-	ch <- prometheus.MustNewConstHistogram(
-		hostchecks, uint64(passiveHostCheckSum), float64(passiveHostCheckSum), map[float64]uint64{
-			1:  uint64(systemStatusDetailObject.Nagioscore.Passivehostchecks.Val1),
-			5:  uint64(systemStatusDetailObject.Nagioscore.Passivehostchecks.Val5),
-			15: uint64(systemStatusDetailObject.Nagioscore.Passivehostchecks.Val15)}, "passive",
-	)
-
-	activeServiceCheckSum := systemStatusDetailObject.Nagioscore.Activeservicechecks.Val1 +
-		systemStatusDetailObject.Nagioscore.Activeservicechecks.Val5 +
-		systemStatusDetailObject.Nagioscore.Activeservicechecks.Val15
-
-	ch <- prometheus.MustNewConstHistogram(
-		servicechecks, uint64(activeServiceCheckSum), float64(activeServiceCheckSum), map[float64]uint64{
-			1:  uint64(systemStatusDetailObject.Nagioscore.Activeservicechecks.Val1),
-			5:  uint64(systemStatusDetailObject.Nagioscore.Activeservicechecks.Val5),
-			15: uint64(systemStatusDetailObject.Nagioscore.Activeservicechecks.Val15)}, "active",
-	)
-
-	passiveServiceCheckSum := systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val1 +
-		systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val5 +
-		systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val15
-
-	ch <- prometheus.MustNewConstHistogram(
-		servicechecks, uint64(passiveServiceCheckSum), float64(passiveServiceCheckSum), map[float64]uint64{
-			1:  uint64(systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val1),
-			5:  uint64(systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val5),
-			15: uint64(systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val15)}, "passive",
-	)
-
-	// active host check performance
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.AvgLatency), "active", "latency", "avg",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.MinLatency), "active", "latency", "min",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.MaxLatency), "active", "latency", "max",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.AvgExecutionTime), "active", "execution", "avg",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.MinExecutionTime), "active", "execution", "min",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		hostchecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activehostcheckperf.MinExecutionTime), "active", "execution", "max",
-	)
-
-	// active service check performance
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.AvgLatency), "active", "latency", "avg",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MinLatency), "active", "latency", "min",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MaxLatency), "active", "latency", "max",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.AvgExecutionTime), "active", "execution", "avg",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MinExecutionTime), "active", "execution", "min",
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		servicechecksPerformance, prometheus.GaugeValue, float64(systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MinExecutionTime), "active", "execution", "max",
-	)
 
 	// user information
 	// we also need to tack on the optional parameter of `advanced` to get privilege information
@@ -675,76 +517,46 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		usersStatus, prometheus.GaugeValue, float64(usersEnabledCount), "enabled",
+		usersStatus, prometheus.GaugeValue, usersEnabledCount, "enabled",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		usersStatus, prometheus.GaugeValue, float64(usersDisabledCount), "disabled",
+		usersStatus, prometheus.GaugeValue, usersDisabledCount, "disabled",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		usersPrivileges, prometheus.GaugeValue, float64(usersAdminCount), "admin",
+		usersPrivileges, prometheus.GaugeValue, usersAdminCount, "admin",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		usersPrivileges, prometheus.GaugeValue, float64(usersRegularCount), "user",
+		usersPrivileges, prometheus.GaugeValue, usersRegularCount, "user",
 	)
+
+	e.UpdateCommonMetrics(ch, hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount,
+		hostsFlapCount, hostsDowntimeCount,
+		servicesCount, servicesActiveCheckCount, servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesCriticalCount, servicesUnknownCount,
+		servicesFlapCount, servicesDowntimeCount,
+		systemStatusDetailObject.Nagioscore.Activehostchecks.Val1, systemStatusDetailObject.Nagioscore.Activehostchecks.Val5, systemStatusDetailObject.Nagioscore.Activehostchecks.Val15,
+		systemStatusDetailObject.Nagioscore.Passivehostchecks.Val1, systemStatusDetailObject.Nagioscore.Passivehostchecks.Val5, systemStatusDetailObject.Nagioscore.Passivehostchecks.Val15,
+		systemStatusDetailObject.Nagioscore.Activeservicechecks.Val1, systemStatusDetailObject.Nagioscore.Activeservicechecks.Val5, systemStatusDetailObject.Nagioscore.Activeservicechecks.Val15,
+		systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val1, systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val5, systemStatusDetailObject.Nagioscore.Passiveservicechecks.Val15, systemStatusDetailObject.Nagioscore.Activehostcheckperf.AvgLatency, systemStatusDetailObject.Nagioscore.Activehostcheckperf.MinLatency, systemStatusDetailObject.Nagioscore.Activehostcheckperf.MaxLatency, systemStatusDetailObject.Nagioscore.Activehostcheckperf.AvgExecutionTime, systemStatusDetailObject.Nagioscore.Activehostcheckperf.MinExecutionTime, systemStatusDetailObject.Nagioscore.Activehostcheckperf.MaxExecutionTime, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.AvgLatency, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MinLatency, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MaxLatency, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.AvgExecutionTime, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MinExecutionTime, systemStatusDetailObject.Nagioscore.Activeservicecheckperf.MaxExecutionTime)
 
 	log.Info("Endpoint scraped and metrics updated")
 }
 
-func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, nagiostatsPath string, nagiosconfigPath string) {
-	// to get specific values, we output them in MRTG format
-	// we pass a comma seperated string of MRTG data - must be manually kept up to date
-	mrtgList := "NAGIOSVERSION,NUMHOSTS,NUMHSTACTCHK60M,NUMHSTPSVCHK60M,NUMHSTUP,NUMHSTDOWN,NUMHSTUNR,NUMHSTFLAPPING,NUMHSTDOWNTIME,NUMSERVICES,NUMSVCACTCHK60M,NUMSVCPSVCHK60M,NUMSVCOK,NUMSVCWARN,NUMSVCUNKN,NUMSVCCRIT,NUMSVCFLAPPING,NUMSVCDOWNTIME,NUMHSTACTCHK1M,NUMHSTACTCHK5M,NUMHSTACTCHK15M,NUMHSTPSVCHK1M,NUMHSTPSVCHK5M,NUMHSTPSVCHK15M,NUMSVCACTCHK1M,NUMSVCACTCHK5M,NUMSVCACTCHK15M,NUMSVCPSVCHK1M,NUMSVCPSVCHK5M,NUMSVCPSVCHK15M,AVGACTHSTLAT,MINACTHSTLAT,MAXACTHSTLAT,AVGACTHSTEXT,MINACTHSTEXT,MAXACTHSTEXT,AVGACTSVCLAT,MINACTSVCLAT,MAXACTSVCLAT,AVGACTSVCEXT,MINACTSVCEXT,MAXACTSVCEXT"
+func (e *Exporter) UpdateCommonMetrics(ch chan<- prometheus.Metric, hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount,
+	hostsFlapCount, hostsDowntimeCount, servicesCount, servicesActiveCheckCount, servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesCriticalCount, servicesUnknownCount,
+	servicesFlapCount, servicesDowntimeCount,
+	activehostchecks1m, activehostchecks5m, activehostchecks15m, passivehostchecks1m, passivehostchecks5m, passivehostchecks15m,
+	activeservicechecks1m, activeservicechecks5m, activeservicechecks15m, passiveservicechecks1m, passiveservicechecks5m, passiveservicechecks15m, activehostchecklatencyavg, activehostchecklatencymin, activehostchecklatencymax, activehostcheckexecutionavg, activehostcheckexecutionmin, activehostcheckexecutionmax, activeservicechecklatencyavg, activeservicechecklatencymin, activeservicechecklatencymax, activeservicecheckexecutionavg, activeservicecheckexecutionmin, activeservicecheckexecutionmax float64) {
 
-	// -m = mrtg; -D = use comma as delimiter, -d = MRTG list input
-	cmd := exec.Command(nagiostatsPath, "-c", nagiosconfigPath, "-m", "-D", ",", "-d", mrtgList)
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	// Metrics common to both collection options
 
-	err := cmd.Run()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Debug("Queried nagiostats: ", out.String())
-	// input our comma seperated list as metrics
-	cmdSplice := strings.Split(out.String(), ",")
-
-	// Need float64 values for metrics
-	metricSlice := make([]float64, 0, len(cmdSplice))
-
-	for _, metric := range cmdSplice {
-		metric, _ := strconv.ParseFloat(metric, 64)
-		metricSlice = append(metricSlice, metric)
-	}
-
-	var nagiosVersion string = cmdSplice[0] // NAGIOSVERSION
-	ch <- prometheus.MustNewConstMetric(
-		// we do want this value to be a string though as it's a label
-		versionInfo, prometheus.GaugeValue, 1, nagiosVersion,
-	)
-
-	// TODO - refactor this so both collection methods only call it once
 	ch <- prometheus.MustNewConstMetric(
 		buildInfo, prometheus.GaugeValue, 1, Version, BuildDate, Commit,
 	)
 
 	// host status
-	var hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount, hostsFlapCount, hostsDowntimeCount float64
-
-	// maintaining variables for each of these makes it slightly easier to parse
-	// its really horrible but not sure there's a better way
-
-	hostsCount = metricSlice[1]             // NUMHOSTS
-	hostsActiveCheckCount = metricSlice[2]  // NUMHSTACTCHK60M - technically only hosts actively checked in last hour
-	hostsPassiveCheckCount = metricSlice[3] // NUMHSTPSVCHK60M
-	hostsUpCount = metricSlice[4]           // NUMHSTUP
-	hostsDownCount = metricSlice[5]         // NUMHSTDOWN
-	hostsUnreachableCount = metricSlice[6]  // NUMHSTUNR
-	hostsFlapCount = metricSlice[7]         // NUMHSTFLAPPING
-	hostsDowntimeCount = metricSlice[8]     // NUMHSTDOWNTIME
 
 	ch <- prometheus.MustNewConstMetric(
 		hostsTotal, prometheus.GaugeValue, hostsCount,
@@ -779,18 +591,6 @@ func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, 
 	)
 
 	// service status
-	var servicesCount, servicesActiveCheckCount,
-		servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesUnknownCount, servicesCriticalCount, servicesFlapCount, servicesDowntimeCount float64
-
-	servicesCount = metricSlice[9]              // NUMSERVICES
-	servicesActiveCheckCount = metricSlice[10]  // NUMSVCACTCHK60M
-	servicesPassiveCheckCount = metricSlice[11] // NUMSVCPSVCHK60M
-	servicesOkCount = metricSlice[12]           // NUMSVCOK
-	servicesWarnCount = metricSlice[13]         // NUMSVCWARN
-	servicesUnknownCount = metricSlice[14]      // NUMSVCUNKN
-	servicesCriticalCount = metricSlice[15]     // NUMSVCCRIT
-	servicesFlapCount = metricSlice[16]         // NUMSVCFLAPPING
-	servicesDowntimeCount = metricSlice[17]     // NUMSVCDOWNTIME
 
 	ch <- prometheus.MustNewConstMetric(
 		servicesTotal, prometheus.GaugeValue, servicesCount,
@@ -864,27 +664,6 @@ func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, 
 			15: uint64(passiveservicechecks15m)}, "passive",
 	)
 
-	var activehostchecklatencyavg, activehostchecklatencymin, activehostchecklatencymax,
-		activehostcheckexecutionavg, activehostcheckexecutionmin, activehostcheckexecutionmax,
-		activeservicechecklatencyavg, activeservicechecklatencymin, activeservicechecklatencymax,
-		activeservicecheckexecutionavg, activeservicecheckexecutionmin, activeservicecheckexecutionmax float64
-
-	activehostchecklatencyavg = metricSlice[30] // AVGACTHSTLAT
-	activehostchecklatencymin = metricSlice[31] // MINACTHSTLAT
-	activehostchecklatencymax = metricSlice[32] // MAXACTHSTLAT
-
-	activehostcheckexecutionavg = metricSlice[33] // AVGACTHSTEXT
-	activehostcheckexecutionmin = metricSlice[34] // MINACTHSTEXT
-	activehostcheckexecutionmax = metricSlice[35] // MAXACTHSTEXT
-
-	activeservicechecklatencyavg = metricSlice[36] // AVGACTSVCLAT
-	activeservicechecklatencymin = metricSlice[37] // MINACTSVCLAT
-	activeservicechecklatencymax = metricSlice[38] // MAXACTSVCLAT
-
-	activeservicecheckexecutionavg = metricSlice[39] // AVGACTSVCEXT
-	activeservicecheckexecutionmin = metricSlice[40] // MINACTSVCEXT
-	activeservicecheckexecutionmax = metricSlice[41] // MAXACTSVCEXT
-
 	// active host check performance
 	ch <- prometheus.MustNewConstMetric(
 		hostchecksPerformance, prometheus.GaugeValue, activehostchecklatencyavg, "active", "latency", "avg",
@@ -934,6 +713,120 @@ func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, 
 	ch <- prometheus.MustNewConstMetric(
 		servicechecksPerformance, prometheus.GaugeValue, activeservicecheckexecutionmax, "active", "execution", "max",
 	)
+
+}
+
+func (e *Exporter) QueryNagiostatsAndUpdateMetrics(ch chan<- prometheus.Metric, nagiostatsPath string, nagiosconfigPath string) {
+	// to get specific values, we output them in MRTG format
+	// we pass a comma seperated string of MRTG data - must be manually kept up to date
+	mrtgList := "NAGIOSVERSION,NUMHOSTS,NUMHSTACTCHK60M,NUMHSTPSVCHK60M,NUMHSTUP,NUMHSTDOWN,NUMHSTUNR,NUMHSTFLAPPING,NUMHSTDOWNTIME,NUMSERVICES,NUMSVCACTCHK60M,NUMSVCPSVCHK60M,NUMSVCOK,NUMSVCWARN,NUMSVCUNKN,NUMSVCCRIT,NUMSVCFLAPPING,NUMSVCDOWNTIME,NUMHSTACTCHK1M,NUMHSTACTCHK5M,NUMHSTACTCHK15M,NUMHSTPSVCHK1M,NUMHSTPSVCHK5M,NUMHSTPSVCHK15M,NUMSVCACTCHK1M,NUMSVCACTCHK5M,NUMSVCACTCHK15M,NUMSVCPSVCHK1M,NUMSVCPSVCHK5M,NUMSVCPSVCHK15M,AVGACTHSTLAT,MINACTHSTLAT,MAXACTHSTLAT,AVGACTHSTEXT,MINACTHSTEXT,MAXACTHSTEXT,AVGACTSVCLAT,MINACTSVCLAT,MAXACTSVCLAT,AVGACTSVCEXT,MINACTSVCEXT,MAXACTSVCEXT"
+
+	// -m = mrtg; -D = use comma as delimiter, -d = MRTG list input
+	cmd := exec.Command(nagiostatsPath, "-c", nagiosconfigPath, "-m", "-D", ",", "-d", mrtgList)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Debug("Queried nagiostats: ", out.String())
+	// input our comma seperated list as metrics
+	cmdSplice := strings.Split(out.String(), ",")
+
+	// Need float64 values for metrics
+	metricSlice := make([]float64, 0, len(cmdSplice))
+
+	for _, metric := range cmdSplice {
+		metric, _ := strconv.ParseFloat(metric, 64)
+		metricSlice = append(metricSlice, metric)
+	}
+
+	var nagiosVersion string = cmdSplice[0] // NAGIOSVERSION
+	ch <- prometheus.MustNewConstMetric(
+		// we do want this value to be a string though as it's a label
+		versionInfo, prometheus.GaugeValue, 1, nagiosVersion,
+	)
+
+	// host status
+	var hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount, hostsFlapCount, hostsDowntimeCount float64
+
+	// maintaining variables for each of these makes it slightly easier to parse
+	// its really horrible but not sure there's a better way
+
+	hostsCount = metricSlice[1]             // NUMHOSTS
+	hostsActiveCheckCount = metricSlice[2]  // NUMHSTACTCHK60M - technically only hosts actively checked in last hour
+	hostsPassiveCheckCount = metricSlice[3] // NUMHSTPSVCHK60M
+	hostsUpCount = metricSlice[4]           // NUMHSTUP
+	hostsDownCount = metricSlice[5]         // NUMHSTDOWN
+	hostsUnreachableCount = metricSlice[6]  // NUMHSTUNR
+	hostsFlapCount = metricSlice[7]         // NUMHSTFLAPPING
+	hostsDowntimeCount = metricSlice[8]     // NUMHSTDOWNTIME
+
+	// service status
+	var servicesCount, servicesActiveCheckCount,
+		servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesUnknownCount, servicesCriticalCount, servicesFlapCount, servicesDowntimeCount float64
+
+	servicesCount = metricSlice[9]              // NUMSERVICES
+	servicesActiveCheckCount = metricSlice[10]  // NUMSVCACTCHK60M
+	servicesPassiveCheckCount = metricSlice[11] // NUMSVCPSVCHK60M
+	servicesOkCount = metricSlice[12]           // NUMSVCOK
+	servicesWarnCount = metricSlice[13]         // NUMSVCWARN
+	servicesUnknownCount = metricSlice[14]      // NUMSVCUNKN
+	servicesCriticalCount = metricSlice[15]     // NUMSVCCRIT
+	servicesFlapCount = metricSlice[16]         // NUMSVCFLAPPING
+	servicesDowntimeCount = metricSlice[17]     // NUMSVCDOWNTIME
+
+	// check performance
+	var activehostchecks1m, activehostchecks5m, activehostchecks15m,
+		passivehostchecks1m, passivehostchecks5m, passivehostchecks15m,
+		activeservicechecks1m, activeservicechecks5m, activeservicechecks15m,
+		passiveservicechecks1m, passiveservicechecks5m, passiveservicechecks15m float64
+
+	activehostchecks1m = metricSlice[18]   // NUMHSTACTCHK1M
+	activehostchecks5m = metricSlice[19]   // NUMHSTACTCHK5M
+	activehostchecks15m = metricSlice[20]  // NUMHSTACTCHK15M
+	passivehostchecks1m = metricSlice[21]  // NUMHSTPSVCHK1M
+	passivehostchecks5m = metricSlice[22]  // NUMHSTPSVCHK5M
+	passivehostchecks15m = metricSlice[23] // NUMHSTPSVCHK15M
+
+	activeservicechecks1m = metricSlice[24]   // NUMSVCACTCHK1M
+	activeservicechecks5m = metricSlice[25]   // NUMSVCACTCHK5M
+	activeservicechecks15m = metricSlice[26]  // NUMSVCACTCHK15M
+	passiveservicechecks1m = metricSlice[27]  // NUMSVCPSVCHK1M
+	passiveservicechecks5m = metricSlice[28]  // NUMSVCPSVCHK5M
+	passiveservicechecks15m = metricSlice[29] // NUMSVCPSVCHK15M
+
+	var activehostchecklatencyavg, activehostchecklatencymin, activehostchecklatencymax,
+		activehostcheckexecutionavg, activehostcheckexecutionmin, activehostcheckexecutionmax,
+		activeservicechecklatencyavg, activeservicechecklatencymin, activeservicechecklatencymax,
+		activeservicecheckexecutionavg, activeservicecheckexecutionmin, activeservicecheckexecutionmax float64
+
+	activehostchecklatencyavg = metricSlice[30] // AVGACTHSTLAT
+	activehostchecklatencymin = metricSlice[31] // MINACTHSTLAT
+	activehostchecklatencymax = metricSlice[32] // MAXACTHSTLAT
+
+	activehostcheckexecutionavg = metricSlice[33] // AVGACTHSTEXT
+	activehostcheckexecutionmin = metricSlice[34] // MINACTHSTEXT
+	activehostcheckexecutionmax = metricSlice[35] // MAXACTHSTEXT
+
+	activeservicechecklatencyavg = metricSlice[36] // AVGACTSVCLAT
+	activeservicechecklatencymin = metricSlice[37] // MINACTSVCLAT
+	activeservicechecklatencymax = metricSlice[38] // MAXACTSVCLAT
+
+	activeservicecheckexecutionavg = metricSlice[39] // AVGACTSVCEXT
+	activeservicecheckexecutionmin = metricSlice[40] // MINACTSVCEXT
+	activeservicecheckexecutionmax = metricSlice[41] // MAXACTSVCEXT
+
+	e.UpdateCommonMetrics(ch, hostsCount, hostsActiveCheckCount, hostsPassiveCheckCount, hostsUpCount, hostsDownCount, hostsUnreachableCount,
+		hostsFlapCount, hostsDowntimeCount,
+		servicesCount, servicesActiveCheckCount, servicesPassiveCheckCount, servicesOkCount, servicesWarnCount, servicesCriticalCount, servicesUnknownCount,
+		servicesFlapCount, servicesDowntimeCount,
+		activehostchecks1m, activehostchecks5m, activehostchecks15m,
+		passivehostchecks1m, passivehostchecks5m, passivehostchecks15m,
+		activeservicechecks1m, activeservicechecks5m, activeservicechecks15m,
+		passiveservicechecks1m, passiveservicechecks5m, passiveservicechecks15m, activehostchecklatencyavg, activehostchecklatencymin, activehostchecklatencymax, activehostcheckexecutionavg, activehostcheckexecutionmin, activehostcheckexecutionmax, activeservicechecklatencyavg, activeservicechecklatencymin, activeservicechecklatencymax, activeservicecheckexecutionavg, activeservicecheckexecutionmin, activeservicecheckexecutionmax)
 
 	log.Info("Nagiostats scraped and metrics updated")
 }

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -1020,13 +1020,22 @@ func main() {
 		log.SetLevel(log.InfoLevel)
 	}
 
-	var conf Config = ReadConfig(*configPath)
+	var nagiosURL string
+	var conf Config
 
-	formatter := nagiosFormatter{}
-	formatter.APIKey = conf.APIKey
-	log.SetFormatter(&formatter)
+	// if we _aren't_ using nagiostats, it'll be a blank string
+	if *statsBinary == "" {
+		conf = ReadConfig(*configPath)
 
-	nagiosURL := *remoteAddress + nagiosAPIVersion + apiSlug
+		formatter := nagiosFormatter{}
+		formatter.APIKey = conf.APIKey
+		log.SetFormatter(&formatter)
+
+		nagiosURL = *remoteAddress + nagiosAPIVersion + apiSlug
+	} else {
+		// if we're using nagiostats, set a dummy API key here
+		conf.APIKey = ""
+	}
 
 	// convert timeout flag to seconds
 	exporter := NewExporter(nagiosURL, conf.APIKey, *sslVerify, time.Duration(*nagiosAPITimeout)*time.Second, *statsBinary, *nagiosConfigPath)

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -1041,7 +1041,12 @@ func main() {
 	exporter := NewExporter(nagiosURL, conf.APIKey, *sslVerify, time.Duration(*nagiosAPITimeout)*time.Second, *statsBinary, *nagiosConfigPath)
 	prometheus.MustRegister(exporter)
 
-	log.Info("Using connection endpoint: ", *remoteAddress)
+	if *statsBinary == "" {
+		log.Info("Using connection endpoint: ", *remoteAddress)
+	} else {
+		log.Info("Using nagiostats binary: ", *statsBinary)
+		log.Info("Using Nagios configiration: ", *nagiosConfigPath)
+	}
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Collecting metrics with the `nagiostats` binary isn't as dynamic as
using Nagios XI's RESTful API, but provides a way to collect metrics on
nearly any flavor of Nagios. The metric collection is significantly
harder to maintain than using Nagios XI's API, and the amount of metrics
that can be collected is limited, but the essential metrics work.

Resolves #6 