### PR TITLE
fix: don't die on connection failures

### DIFF
--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -243,7 +243,7 @@ func (e *Exporter) TestNagiosConnectivity(sslVerify bool, nagiosAPITimeout time.
 
 	jsonErr := json.Unmarshal(body, &systemStatusObject)
 	if jsonErr != nil {
-		log.Fatal(jsonErr)
+		return 0
 	}
 
 	return systemStatusObject.Running


### PR DESCRIPTION
As reported by @wbh1, this sets the `nagios_up` metric to `0` instead of killing nagios_exporter if there are issue querying the Nagios XI API.

Resolves #27