### PR TITLE
grafana: add units for bottom panels

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1745,7 +1745,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -2418,7 +2419,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -2543,7 +2545,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -2669,7 +2672,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },


### PR DESCRIPTION
We use "short" which turns (say) "9000" into "9k", making the axis and legend more compact and readable.

I have tried to change the histogram panels to heat maps, but it was unwieldy and confusing, but those should also display "minutes" or something.