### PR TITLE
grafana: logarithmic scale for service/host counts

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1720,7 +1720,8 @@
             "lineWidth": 4,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1845,7 +1846,8 @@
             "lineWidth": 4,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,


### PR DESCRIPTION
Those can get pretty large: in our case we're at 4k service checks, and we have 20 of those warning right now, which makes them completely invisible in the graph. By making the axis logarithmic, we're able to see progression on those lines as well.