### PR TITLE
fix: only warn if version getter fails

### DIFF
--- a/get_nagios_version/get_nagios_version.go
+++ b/get_nagios_version/get_nagios_version.go
@@ -1,11 +1,9 @@
 package get_nagios_version
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/html"
 )
 
@@ -14,15 +12,13 @@ func GetLatestNagiosXIVersion(NagiosXIURL string) (version string, err error) {
 	// Fetch the HTML source data from the URL
 	resp, err := http.Get(NagiosXIURL)
 	if err != nil {
-		fmt.Println("Error fetching HTML:", err)
-		return
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	// Parse the HTML data into a tree structure
 	doc, err := html.Parse(resp.Body)
 	if err != nil {
-		log.Info(err)
 		return "", err
 	}
 

--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -461,7 +461,8 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 	if checkUpdates {
 		nagiosVersion, err := get_nagios_version.GetLatestNagiosXIVersion(NagiosXIURL)
 		if err != nil {
-			log.Fatal(err)
+			// don't abandon exporter just for version updater issues
+			log.Warn(err)
 		}
 
 		updateMetric := CompareNagiosVersions(nagiosVersion, systemInfoObject.Version)


### PR DESCRIPTION
rather than exit the program, return all errors outside function and throw warnings